### PR TITLE
Added functionality for `article` search without ID specifier.

### DIFF
--- a/web/graphql/simple_blog_schema.ex
+++ b/web/graphql/simple_blog_schema.ex
@@ -53,9 +53,12 @@ defmodule GraphQL.Schema.SimpleBlog do
       name: "Query",
       fields: %{
         article: %{
-          type: article,
+          type: %List{ofType: article},
           args: %{id: %{type: %ID{}}},
-          resolve: fn(_, %{id: id}, _) -> make_article(id) end
+          resolve: fn
+            _, %{id: id}, _ -> [make_article(id)]
+            _, _, _         -> for id <- 1..2, do: make_article(id)
+          end
         },
         feed: %{
           type: %List{ofType: article},


### PR DESCRIPTION
Helps newbies who use this as a starting point for GraphQL see a typical schema that includes the ability to query by ID of an object, but not the stipulation you must always use an ID. Also changed return of `article` to list per GraphQL convention.
